### PR TITLE
Add Gitbook build support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+language: node_js
+
+node_js:
+  - "8"
+
+# 缓存依赖
+cache:
+  directories:
+    - $HOME/.npm
+
+before_install:
+  - export TZ='Asia/Shanghai' # 更改时区
+
+# 依赖安装
+install:
+  - npm install -g gitbook-cli gitbook-summary
+
+# 构建脚本
+script:
+    # 自定义输出目录 gitbook build src dest
+  - cd ./blog
+  - gitbook install
+  - book sm
+  - cat SUMMARY.md
+  - gitbook build . ../blog-build
+
+# 分支白名单
+branches:
+  only:
+    - master # 只对 master 分支进行构建
+
+# GitHub Pages 部署
+deploy:
+  provider: pages
+  skip_cleanup: true
+  # 在项目仪表盘的 Settings -> Environment Variables 中配置
+  github_token: $GITHUB_TOKEN
+  # 将 build 目录下的内容推送到默认的 gh-pages 分支上，并不会连带 build 目录一起
+  local_dir: blog-build
+  name: $GIT_NAME
+  email: $GIT_EMAIL
+  on:
+    branch: master

--- a/blog/README.md
+++ b/blog/README.md
@@ -1,0 +1,62 @@
+# Learn React Source Code
+
+* [Day1 - Guidance](guidance.md)
+* [Day2 - Mounting](mounting.md)
+* [Day3 - Mounting - Contd](mounting-contd.md)
+* [Day4 - Updating - The Process Flow](update.md)
+* [Day5 - Updating - Diff](update-contd.md)
+* [Day6 - Updating - Real DOM Update](update-dom.md)
+
+## What You'll Learn
+
+* React 是怎样将 JSX mount 成为真正的 DOM 节点的
+* React 是怎样用 Virtual DOM 的 Diff 算法更新 Element tree，然后映射到真正的 DOM 变化的
+* 什么是 Virtual DOM，它的优势是什么，以及它和 React 是怎样结合使用的
+* 对 React 的核心功能有一个更深入的理解
+
+## What This Doesn't Cover
+
+由于这是一个 React 的最小实现，它并没有实现 React 的全部功能，以下这些功能是这个代码库没有涵盖到的。（这个 list 在 Paul 2016 的演讲中被提及到）
+
+* `defaultProps`
+* `propTypes`
+* `keys`
+* `refs`
+* batching
+* events
+* createClass
+* warnings
+* browser
+* optimizations
+* rendering null
+* DOM updates
+* SVG
+* life cycle hooks
+* error boundaries
+* perf tooling and optimizing
+* `PureComponents`
+* functional components
+
+但是当你读完整个博客和代码后，相信你已经会有对实现这其中的几个功能的一些初步思考。
+
+## Run the Demo
+
+```sh
+> cd ./demo
+> npm install
+> npm run watch
+```
+
+Open the `index.html` manually.
+
+## Disclaimers
+
+1. Most code of Dilithium you've seen in this repo is originally written by [@zpao](https://github.com/zpao), at [building-react-from-scratch](https://github.com/zpao/building-react-from-scratch), but it's also slightly changed here. I'll keep digging some of the listed features and adding blog and source code on top of the current codebase.
+
+2. The diffing algorithm used in the Dilithium is the stack reconcilliation, not the new fiber architecture.
+
+3. The code snippets in the blogs are sometimes somewhat different from that in the codebase. This is for better readablity and a more smooth learning curve.
+
+## Liscense
+
+MIT[@Chang](github.com/cyan33)

--- a/blog/book.json
+++ b/blog/book.json
@@ -1,0 +1,69 @@
+{
+    "title": "Learn React Source Code",
+    "author": "cyan33",
+    "links": {
+        "sidebar": {
+            "Learn React Source Code": "https://github.com/cyan33/learn-react-source-code"
+        }
+    },
+    "plugins": [
+        "-lunr",
+        "-search",
+        "search-plus",
+        "splitter",
+        "anchors",
+        "anchor-navigation-ex",
+        "copy-code-button",
+        "expandable-chapters",
+        "theme-darkblue",
+        "theme-comscore",
+        "tbfed-pagefooter",
+        "prism",
+        "-highlight",
+        "github-buttons",
+        "edit-link",
+        "disqus"
+    ],
+    "pluginsConfig": {
+        "tbfed-pagefooter": {
+            "modify_label": "最近更新：",
+            "modify_format": "YYYY-MM-DD HH:mm"
+        },
+        "prism": {
+            "css": [
+                "prismjs/themes/prism-tomorrow.css"
+            ]
+        },
+        "github-buttons": {
+            "buttons": [{
+                "user": "cyan33",
+                "repo": "learn-react-source-code",
+                "type": "star",
+                "size": "small",
+                "count": true
+            }]
+        },
+        "edit-link": {
+            "base": "https://github.com/cyan33/learn-react-source-code/edit/master/blog",
+            "label": "Edit This Page"
+        },
+        "sharing": {
+            "facebook": false,
+            "twitter": true,
+            "weibo": true
+        },
+        "disqus": {
+            "shortName": "gitbook-8"
+        },
+        "anchor-navigation-ex": {
+            "multipleH1": false
+        }
+    },
+    "ignores": [
+        ".*",
+	"build",
+        "_book",
+        "gitbook",
+        "node_modules"
+    ]
+}

--- a/blog/mounting-contd.md
+++ b/blog/mounting-contd.md
@@ -28,10 +28,12 @@ mountComponent() {
 ```jsx
   <div
     className="container"
+    {% raw %}
     style={{
       color: 'red',
       fontSize: '24px'
     }}
+    {% endraw %}
   >
     Hello World
   </div>


### PR DESCRIPTION
With Gitbook and Travis CI, building an online version of this tutorial only need 2 steps

[Gitbook Live Demo](https://dragonforker.github.io/learn-react-source-code) -> [Repo](https://github.com/dragonforker/learn-react-source-code)

## Enable CI build on [travis.org](https://travis-ci.org)

Just need to complete step 2 of https://docs.travis-ci.com/user/getting-started#To-get-started-with-Travis-CI

## Define `GITHUB_TOKEN`, `GIT_NAME` and `GIT_EMAIL` environment variables

As https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings said, set:
- `GITHUB_TOKEN` with `repo` access to deploy building result to `gh-pages` branch
- `GIT_NAME` to `cyan33`
- `GIT_EMAIL` to `cyan.binary@gmail.com`